### PR TITLE
Add manual, admin-approved PyPI publish workflow (trusted publishing)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,94 @@
+name: Publish to PyPI
+
+# Manual releases only. Triggered from the Actions tab by a maintainer,
+# then held for approval by the required reviewers of the `release`
+# environment before anything is uploaded to PyPI.
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - name: Install build tools
+        run: python -m pip install --upgrade build twine
+      - name: Build sdist and wheel
+        run: python -m build
+      - name: Check distribution metadata
+        run: python -m twine check --strict dist/*
+      - name: Read package version
+        id: version
+        run: |
+          VERSION=$(python -c "from pathlib import Path; print(next(Path('dist').glob('*.whl')).name.split('-')[1])")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Built version: $VERSION"
+      - name: Fail if version already exists on PyPI
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          python - <<'EOF'
+          import json
+          import os
+          import sys
+          import urllib.request
+
+          version = os.environ["VERSION"]
+          url = "https://pypi.org/pypi/currency-symbols/json"
+          with urllib.request.urlopen(url) as response:
+              releases = json.load(response)["releases"]
+          if version in releases:
+              sys.exit(
+                  f"Version {version} is already on PyPI. "
+                  "Bump the version before publishing."
+              )
+          print(f"Version {version} is not on PyPI yet. OK to publish.")
+          EOF
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI (requires approval)
+    needs: build
+    runs-on: ubuntu-latest
+    # The `release` environment must be configured with required
+    # reviewers so this job pauses until an admin approves it.
+    environment:
+      name: release
+      url: https://pypi.org/project/currency-symbols/${{ needs.build.outputs.version }}/
+    permissions:
+      # Required for PyPI trusted publishing (OIDC). No API token needed.
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Tag and create GitHub release
+    needs: [build, publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+      - name: Create tag and GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          gh release create "v$VERSION" \
+            --target "${{ github.sha }}" \
+            --title "v$VERSION" \
+            --generate-notes

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,21 +1,46 @@
-## Release
+# Release
 
-- Build the project using below command
+Releases are published through the [Publish to PyPI](.github/workflows/publish.yml)
+GitHub Actions workflow. It is triggered manually and pauses for admin
+approval before anything is uploaded. No PyPI tokens are stored in the
+repository — authentication uses [PyPI trusted publishing](https://docs.pypi.org/trusted-publishers/) (OIDC).
+
+## Publishing a release
+
+1. Bump the package version on `master` (merge a version-bump PR).
+2. Go to **Actions → Publish to PyPI → Run workflow** and run it on `master`.
+3. The `build` job builds the sdist + wheel, validates metadata with
+   `twine check`, and fails fast if the version already exists on PyPI.
+4. The `publish` job waits for approval from the required reviewers of the
+   `release` environment. Approve it to publish.
+5. After a successful upload, the workflow creates the `v<version>` git tag
+   and a GitHub release with auto-generated notes.
+
+## One-time setup (already required before first run)
+
+### 1. PyPI trusted publisher
+
+On PyPI: **currency-symbols → Manage → Publishing → Add a new publisher**
+
+| Field | Value |
+| --- | --- |
+| Owner | `arshadkazmi42` |
+| Repository | `currency-symbols` |
+| Workflow name | `publish.yml` |
+| Environment | `release` |
+
+### 2. GitHub `release` environment
+
+On GitHub: **Settings → Environments → New environment** named `release`.
+Enable **Required reviewers** and add the admin(s) who may approve
+releases. This is what enforces the manual approval gate.
+
+## Manual publishing (fallback)
+
+If the workflow is unavailable:
 
 ```
-python3 setup.py sdist bdist_wheel 
-```
-
-- Publish to test pypi repository to test all the changes
-
-```
-python3 -m twine upload --repository testpypi dist/*
-```
-
-- Publish to pypi repository
-
-```
+python3 -m pip install --upgrade build twine
+python3 -m build
 python3 -m twine upload dist/*
 ```
-
-**--skip-existing**: Use this flag to override an existing version


### PR DESCRIPTION
## What

Adds `.github/workflows/publish.yml` — a **manually triggered** release pipeline — and rewrites `RELEASE.md` to document it.

Flow: **Actions tab → Run workflow → build + checks → ⏸ waits for admin approval → publish to PyPI → auto tag + GitHub release.**

- **`workflow_dispatch` only** — it never fires automatically; only users with write access see the Run workflow button.
- **Admin approval gate** — the publish job runs in a `release` environment; once you add yourself as a required reviewer, every run pauses until you approve it, even if a collaborator triggered it.
- **PyPI trusted publishing (OIDC)** — no API token stored in repo secrets, which removes the stolen-token supply-chain risk entirely. Given 3M downloads/month, this is the setup PyPI recommends.
- **Safety checks before upload** — `twine check --strict` on the built dists, and a guard that fails the run if the version already exists on PyPI (so forgetting to bump can't clobber/no-op a release).
- **Post-publish** — creates the `v<version>` git tag and a GitHub release with generated notes automatically.

## One-time setup needed after merge (documented in RELEASE.md)

1. On PyPI → currency-symbols → Publishing → add trusted publisher: owner `arshadkazmi42`, repo `currency-symbols`, workflow `publish.yml`, environment `release`.
2. On GitHub → Settings → Environments → create `release` → enable **Required reviewers** → add yourself.

## Notes

- Fully independent of the other PRs; works with the current `setup.py` and with the pyproject migration (`python -m build` handles both).
- Context: master currently has currencies (XCG, ZWG, …) merged after v2.0.4 that never got published — this workflow + a version bump gets them out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)