### PR TITLE
Modernize CI: Python 3.9–3.14 matrix, bump actions, add packaging check

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,17 +5,32 @@ on:
   - push
 
 jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+      - name: Install build tools
+        run: python -m pip install --upgrade build twine
+      - name: Build sdist and wheel
+        run: python -m build
+      - name: Check distribution metadata
+        run: python -m twine check --strict dist/*
+
   build:
 
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
## What

- **Test matrix → 3.9–3.14.** The current matrix (3.8–3.11) tests one EOL version (3.8, dead since Oct 2024) and misses 3.12/3.13/3.14 — the versions the bulk of 3M monthly downloads actually run on.
- **Bump deprecated action generations**: `actions/checkout` v3 → v7, `actions/setup-python` v4 → v6 (v3/v4 are on the deprecated node runtimes).
- **New `package` job**: builds the sdist + wheel and runs `twine check --strict` on every push/PR, so a broken `setup.py`/`pyproject.toml` or README rendering issue is caught in CI instead of during a release.

## Notes

- Independent of the other PRs. It shares `pytest.yml` with the test-suite PR (#42) but touches different lines (matrix/actions here, the test command there) — they merge cleanly in either order.
- The `package` job works both with today's `setup.py` and with the pyproject migration PR, since `python -m build` supports both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)