### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` covering the `github-actions` ecosystem, monthly cadence.

## Why

The CI workflow was sitting on `checkout@v3` / `setup-python@v4` (deprecated node runtimes) with nobody noticing. Dependabot turns that into an occasional one-click PR. No `pip` ecosystem entry — the package has zero runtime dependencies.

Independent of all other PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)