### PR TITLE
Bump version to 2.0.5

### DIFF
--- a/currency_symbols/__init__.py
+++ b/currency_symbols/__init__.py
@@ -2,7 +2,7 @@
 
 from .currency_symbols import CurrencySymbols
 
-__version__ = "2.0.4"
+__version__ = "2.0.5"
 
 __all__ = [
     "CurrencySymbols"


### PR DESCRIPTION
## What

`__version__` `2.0.4` → `2.0.5`, one line. (Rebased onto master after #46 — the version now lives in `currency_symbols/__init__.py` and pyproject reads it from there.)

## Why

PyPI's latest release is 2.0.4 (May 2025), but master already contains currencies merged after that in #40 — **XCG (Caribbean guilder, which replaced ANG in 2025)**, ZWG (Zimbabwe Gold), ZWN and ZWR. None of it has shipped, so PyPI users can't resolve these codes. Merging this makes master publishable as 2.0.5.

Verified locally: `python -m build` produces `currency_symbols-2.0.5` artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)