### PR TITLE
Add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,51 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `XCG` (Caribbean guilder, replaces ANG), `ZWG` (Zimbabwe Gold), `ZWN`, `ZWR` ([#40](https://github.com/arshadkazmi42/currency-symbols/pull/40))
+
+### Changed
+
+- Currency map is sorted alphabetically by currency code ([#40](https://github.com/arshadkazmi42/currency-symbols/pull/40))
+
+## [2.0.4] - 2025-05-16
+
+### Added
+
+- `CLF`, `CNH`, `DEM`, `FRF`, `SLE`, `VES`, `XAG`, `XAU`, `XDR`, `ZMK`, `ZMW`, `ZWL` ([#38](https://github.com/arshadkazmi42/currency-symbols/pull/38))
+
+## [2.0.3] - 2022-07-10
+
+### Changed
+
+- Moved CI from Travis to GitHub Actions
+
+## [2.0.2] - 2022-03-29
+
+### Added
+
+- `KZT` (₸)
+- Release documentation (`RELEASE.md`)
+
+### Changed
+
+- Added static typing, docstrings and flake8 linting
+
+## [2.0.1] - 2021-10-04
+
+Older releases predate this changelog; see the
+[git history](https://github.com/arshadkazmi42/currency-symbols/commits/master)
+and [PyPI release history](https://pypi.org/project/currency-symbols/#history).
+
+[Unreleased]: https://github.com/arshadkazmi42/currency-symbols/compare/v2.0.4...HEAD
+[2.0.4]: https://github.com/arshadkazmi42/currency-symbols/compare/v2.0.3...v2.0.4
+[2.0.3]: https://github.com/arshadkazmi42/currency-symbols/compare/v2.0.2...v2.0.3
+[2.0.2]: https://github.com/arshadkazmi42/currency-symbols/compare/v2.0.1...v2.0.2
+[2.0.1]: https://github.com/arshadkazmi42/currency-symbols/releases/tag/v2.0.1


### PR DESCRIPTION
## What

Adds a `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com) format, reconstructed from git tags and PR history back to v2.0.1, with compare links per release.

Includes an **Unreleased** section documenting what's merged but not yet on PyPI (XCG, ZWG, ZWN, ZWR + alphabetical sorting from #40) — exactly what would ship as 2.0.5.

## Why

With ~3M downloads/month, users (and their security/compliance tooling) check the changelog before upgrading. Going forward: add a line to Unreleased in each PR, and rename the section to the version number at release time.

Independent of all other PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)